### PR TITLE
feat: disable TLS 1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ send log entries.
 
 from setuptools import setup, find_packages
 
-VERSION = '0.1.5'
+VERSION = '0.1.6'
 
 setup(
     name='djehouty',


### PR DESCRIPTION
ref: OB-4930

Djehouty, an old LDP library written for python 2, struggle to connect using TLS 1.3. This PR prevents a TLSv1.3 connection.